### PR TITLE
Fix CSS positioning for footer on small screens

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -1,5 +1,8 @@
 body {
   background-color: #f5f5f5; /* Adjust as needed */
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
 }
 
 .navbar-brand {
@@ -10,9 +13,8 @@ body {
   background-color: #343a40;
   color: #fff;
   padding: 1rem 0;
-  position: fixed;
-  bottom: 0;
   width: 100%;
+  margin-top: auto;
 }
 
 .table {


### PR DESCRIPTION
This PR fixes an issue where the footer could cause layout issues on smaller screens. The footer was previously set to `position: fixed` which can overlap content if the content exceeds the viewport height.

The solution changes the layout to use a modern flexbox sticky footer. The body now has `display: flex; flex-direction: column; min-height: 100vh;` and the footer has `margin-top: auto;`. This ensures the footer still sticks to the bottom of the viewport when the page content is short, without overlapping the content when it is long.

---
*PR created automatically by Jules for task [10274617143242620419](https://jules.google.com/task/10274617143242620419) started by @void-cc*