### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-03-02 - Add ARIA Labels to Icon-Only Buttons
+**Learning:** Icon-only buttons (like `+` and `x` for adding and deleting notes) in the Django template views lacked essential accessibility attributes, which is a common oversight in backend-heavy projects. Adding `aria-label` along with `title` makes the UI accessible to screen readers while simultaneously adding a helpful native tooltip for mouse users.
+**Action:** When adding or reviewing interactive UI elements (especially FontAwesome icon buttons), habitually verify that an `aria-label` or visually hidden text exists. Include `title` attributes for dual-purpose accessibility/usability improvements.

--- a/templates/chart.html
+++ b/templates/chart.html
@@ -40,7 +40,7 @@
               <form action="{% url 'delete_annotation' annotation_id=annotation.id %}" method="post" class="d-inline ms-2">
                 {% csrf_token %}
                 <input type="hidden" name="next" value="{% url 'chart' test_name=test_name %}">
-                <button type="submit" class="btn btn-sm btn-link text-danger p-0"><i class="fas fa-times"></i></button>
+                <button type="submit" class="btn btn-sm btn-link text-danger p-0" aria-label="Delete note" title="Delete note"><i class="fas fa-times"></i></button>
               </form>
             </div>
           {% empty %}
@@ -53,7 +53,7 @@
             <input type="hidden" name="next" value="{% url 'chart' test_name=test_name %}">
             <div class="input-group input-group-sm" style="width: 250px;">
               <input type="text" name="note" class="form-control" placeholder="Add note...">
-              <button type="submit" class="btn btn-outline-secondary"><i class="fas fa-plus"></i></button>
+              <button type="submit" class="btn btn-outline-secondary" aria-label="Add note" title="Add note"><i class="fas fa-plus"></i></button>
             </div>
           </form>
         </td>

--- a/templates/index.html
+++ b/templates/index.html
@@ -113,7 +113,7 @@
                 <form action="{% url 'delete_annotation' annotation_id=annotation.id %}" method="post" class="d-inline">
                   {% csrf_token %}
                   <input type="hidden" name="next" value="{% url 'index' %}">
-                  <button type="submit" class="btn btn-sm btn-link text-danger p-0"><i class="fas fa-times"></i></button>
+                  <button type="submit" class="btn btn-sm btn-link text-danger p-0" aria-label="Delete note" title="Delete note"><i class="fas fa-times"></i></button>
                 </form>
               </div>
             {% endfor %}
@@ -122,7 +122,7 @@
               <input type="hidden" name="next" value="{% url 'index' %}">
               <div class="input-group input-group-sm">
                 <input type="text" name="note" class="form-control" placeholder="Add a note...">
-                <button type="submit" class="btn btn-outline-secondary btn-sm"><i class="fas fa-plus"></i></button>
+                <button type="submit" class="btn btn-outline-secondary btn-sm" aria-label="Add note" title="Add note"><i class="fas fa-plus"></i></button>
               </div>
             </form>
           </div>


### PR DESCRIPTION
💡 What: Added `aria-label` and `title` attributes to the "delete annotation" (times icon) and "add annotation" (plus icon) buttons in the dashboard (`index.html`) and chart (`chart.html`) views.
🎯 Why: Icon-only buttons are confusing for screen reader users and can be ambiguous for mouse users. This provides native tooltips and proper accessibility semantics.
♿ Accessibility: Improves accessibility for screen readers and keyboard navigation by providing a clear, descriptive label for the action.

---
*PR created automatically by Jules for task [10977807705444433358](https://jules.google.com/task/10977807705444433358) started by @void-cc*